### PR TITLE
Fix ability to show/hide grid lines in timeseries panel

### DIFF
--- a/grafonnet/timeseries_panel.libsonnet
+++ b/grafonnet/timeseries_panel.libsonnet
@@ -118,7 +118,7 @@
             [if axisWidth != 'auto' then 'axisWidth']: axisWidth,
             [if axisSoftMin != null then 'axisSoftMin']: axisSoftMin,
             [if axisSoftMax != null then 'axisSoftMax']: axisSoftMax,
-            [if axisShowGridLines != 'auto' then 'axisShowGrid']: axisShowGridLines,
+            [if axisShowGridLines != 'auto' then 'axisGridShow']: axisShowGridLines,
             barAlignment: {
               left: -1,
               center: 0,


### PR DESCRIPTION
There was a typo - `axisShowGrid` should've been `axisGridShow`.

Thanks to @eremid for the catch.