### PR TITLE
Sync table and timeseries panels

### DIFF
--- a/grafonnet/table_panel.libsonnet
+++ b/grafonnet/table_panel.libsonnet
@@ -6,41 +6,42 @@
    * @name tablePanel.new
    *
    * @param title The title of the table panel.
-   * @param description (optional) Description of the panel
-   * @param datasource (optional) Datasource
-   * @param unit (optional) The unit to use for values
-   * @param decimals (optional) The number of decimal places to display
-   * @param display_name (optional) Override the series name
-   * @param header (default: `true`) Whether to show the table header
-   * @param footer (default: `false`) Whether to show the table footer
-   * @param footer_calculation (default: `'sum'`) The reducer function / calculation to display in the footer
-   * @param footer_field (optional) The field to display in the footer
-   * @param pagination (default: `false`) Whether to offer pagination of results
-   * @param min_column_width (optional) The minimum width for column auto resizing
-   * @param column_width (optional) The column width
-   * @param column_align (default: `'auto'`) The column alignment (`'auto'`, `'left'`, `'center'`, or `'right'`)
-   * @param column_filter (default: `false`) Enable/disable column filters
-   * @param cell_display_mode (default: `'auto'`) How to display cell values (`'auto'`, `'color-text'`, `'color-background'`, `'color-background-solid'`, `'gradient-gauge'`, `'lcd-gauge'`, `'basic'`. `'json-view'`)
-   * @param cell_value_inspect (default `'false'`) Enable cell value inspection in a modal window
-   * @param no_value (optional) What to show when there is no value
-   * @param transparent (default: `false`) Whether to display the panel without a background
-   * @param sort_by (optional) The series to sort rows by
-   * @param sort_ascending (default: `true`) Whether to sort in ascending or descending order when `sort_by` is set
+   * @param description (optional) The description of the panel.
+   * @param datasource (optional) Datasource.
+   * @param transparent (default `false`) Whether to display the panel without a background.
+   * @param unit (optional) The unit to use for values.
+   * @param decimals (optional) The number of decimal places to display.
+   * @param displayName (optional) Override the series or field name.
+   * @param noValue (optional) What to show when there is no value.
+   * @param thresholdMode (default `'absolute'`) Whether thresholds are absolute or a percentage. `'absolute'` or `'percentage'`.
+   * @param header (default `true`) Whether to show the table header.
+   * @param footer (default `false`) Whether to show the table footer.
+   * @param footerCalculation (default: `'sum'`) The reducer function / calculation to display in the footer.
+   * @param footerField (optional) The field to display in the footer.
+   * @param pagination (default `false`) Whether to offer pagination of results.
+   * @param minColumnWidth (optional) The minimum width for column auto resizing.
+   * @param columnWidth (optional) The column width.
+   * @param columnAlign (default `'auto'`) The column alignment (`'auto'`, `'left'`, `'center'`, or `'right'`).
+   * @param columnFilter (default `false`) Enable/disable column filters.
+   * @param cellDisplayMode (default `'auto'`) How to display cell values (`'auto'`, `'color-text'`, `'color-background'`, `'color-background-solid'`, `'gradient-gauge'`, `'lcd-gauge'`, `'basic'`. `'json-view'`).
+   * @param cellValueInspect (default `'false'`) Enable cell value inspection in a modal window.
+   * @param sortBy (optional) The series to sort rows by.
+   * @param sortAscending (default: `true`) Whether to sort in ascending or descending order when `sortBy` is set.
    * @param links (optional) Array of links for the panel.
    * @param repeat (optional) Name of variable that should be used to repeat this panel.
    * @param repeatDirection (default `'h'`) 'h' for horizontal or 'v' for vertical.
-   * @param repeatMaxPerRow (optional) How many panels to limit each row to when repeating horizontally,
-   * @param thresholdMode (default `'absolute'`) Whether thresholds are absolute or a percentage. `'absolute'` or `'percentage'`
-   * @return A json that represents a table panel
+   * @param repeatMaxPerRow (optional) How many panels to limit each row to when repeating horizontally.
+   * @return A json that represents a table panel.
    *
+   * @method addTarget(target) Adds a target object.
+   * @method addTargets(targets) Adds an array of targets.
+   * @method addLink(link) Add a link to the panel.
+   * @method addLinks(links) Adds an array of links to the panel.
    * @method addThreshold(color, value=null) Adds a threshold.
-   * @method addTarget(target) Adds a target object
-   * @method addTargets(targets) Adds an array of targets
    * @method addValueMapping(value, color, displayText=null) Adds a value mapping.
    * @method addRangeMapping(from, to, color, displayText=null) Adds a range mapping.
    * @method addRegexMapping(pattern, color, displayText=null) Adds a regular expression mapping.
    * @method addSpecialMapping(match, color, displayText=null) Adds a special mapping.
-   * @method addLink(link) Adds a link
    * @method addOverridesForField(field, overrides) Add a list of overrides for a named field.
    * @method addOverridesForFieldsMatchingRegex(regex, overrides) Add a list of overrides for field names matching a given regex.
    * @method addOverridesForFieldsOfType(type, overrides) Add a list of overrides for fields of a given type.
@@ -50,29 +51,29 @@
     title,
     description=null,
     datasource=null,
+    transparent=false,
     unit=null,
     decimals=null,
-    display_name=null,
+    displayName=null,
+    noValue=null,
+    thresholdMode='absolute',
     header=true,
     footer=false,
-    footer_calculation='sum',
-    footer_field=null,
+    footerCalculation='sum',
+    footerField=null,
     pagination=false,
-    min_column_width=null,
-    column_width=null,
-    column_align='auto',
-    column_filter=false,
-    cell_display_mode='auto',
-    cell_value_inspect=false,
-    no_value=null,
-    transparent=false,
-    sort_by=null,
-    sort_ascending=true,
+    minColumnWidth=null,
+    columnWidth=null,
+    columnAlign='auto',
+    columnFilter=false,
+    cellDisplayMode='auto',
+    cellValueInspect=false,
+    sortBy=null,
+    sortAscending=true,
     links=[],
     repeat=null,
     repeatDirection='h',
     repeatMaxPerRow=null,
-    thresholdMode='absolute',
   ):: {
     type: 'table',
     title: title,
@@ -81,12 +82,12 @@
     fieldConfig: {
       defaults: {
         custom: {
-          align: column_align,
-          displayMode: cell_display_mode,
-          inspect: cell_value_inspect,
-          [if min_column_width != null then 'minWidth']: min_column_width,
-          [if column_width != null then 'width']: column_width,
-          [if column_filter then 'filterable']: column_filter,
+          align: columnAlign,
+          displayMode: cellDisplayMode,
+          inspect: cellValueInspect,
+          [if minColumnWidth != null then 'minWidth']: minColumnWidth,
+          [if columnWidth != null then 'width']: columnWidth,
+          [if columnFilter then 'filterable']: columnFilter,
         },
         mappings: [],
         thresholds: {
@@ -98,32 +99,39 @@
         },
         [if unit != null then 'unit']: unit,
         [if decimals != null then 'decimals']: decimals,
-        [if display_name != null then 'displayName']: display_name,
-        [if no_value != null then 'noValue']: no_value,
+        [if displayName != null then 'displayName']: displayName,
+        [if noValue != null then 'noValue']: noValue,
       },
       overrides: [],
     },
     datasource: datasource,
+    links: links,
     options: {
       showHeader: header,
       footer: {
         show: footer,
-        reducer: [footer_calculation],
-        fields: if footer_field != null then [footer_field] else '',
+        reducer: [footerCalculation],
+        fields: if footerField != null then [footerField] else '',
         [if pagination then 'enablePagination']: true,
       },
-      [if sort_by != null then 'sortBy']: [{ desc: if sort_ascending then false else true, displayName: sort_by }],
+      [if sortBy != null then 'sortBy']: [{ desc: if sortAscending then false else true, displayName: sortBy }],
     },
-    links: links,
     [if repeat != null then 'repeat']: repeat,
     [if repeat != null then 'repeatDirection']: repeatDirection,
     [if repeat != null && repeatDirection == 'h' && repeatMaxPerRow != null then 'maxPerRow']: repeatMaxPerRow,
+    targets: [],
     pluginVersion: '9.2.1',
     _nextTarget:: 0,
     addThreshold(color, value=null):: self {
       fieldConfig+: { defaults+: { thresholds+: { steps+: [{ color: color, value: value }] } } },
     },
+    addLink(link):: self {
+      links+: [link],
+    },
+    addLinks(links):: std.foldl(function(p, t) p.addLink(t), links, self),
     addTarget(target):: self {
+      // automatically ref id in added targets.
+      // https://github.com/kausalco/public/blob/master/klumps/grafana.libsonnet
       local nextTarget = super._nextTarget,
       _nextTarget: nextTarget + 1,
       targets+: [target { refId: std.char(std.codepoint('A') + nextTarget) }],
@@ -171,9 +179,6 @@
           [if displayText != null then 'text']: displayText,
         },
       }),
-    addLink(link):: self {
-      links+: [link],
-    },
     addTransformation(transformation):: self {
       transformations+: [transformation],
     },

--- a/grafonnet/timeseries_panel.libsonnet
+++ b/grafonnet/timeseries_panel.libsonnet
@@ -7,54 +7,58 @@
    *
    * @param title The title of the graph panel.
    * @param description (optional) The description of the panel.
+   * @param transparent (default `false`) Whether to display the panel without a background.
+   * @param unit (optional) The unit to use for values.
+   * @param min (optional) The minimum value to display.
+   * @param max (optional) The maximum value to display.
+   * @param decimals (optional) The number of decimal places to display.
+   * @param displayName (optional) Override the series or field name.
+   * @param colorMode (default `'palette-classic'`) The color mode to use.
+   * @param colorBy (default `'last'`) How to determine the color to use. `'last'`, `'min'`, or `'max'`.
+   * @param fixedColor (optional) The color to use when `colorMode` is `'fixed'`.
+   * @param noValue (optional) What to show when there is no value.
+   * @param thresholdDisplay (default `'off'`) How thresholds should be visualised. `'off'`, `'line'`, `'area'`, or `'line+area'`.
+   * @param thresholdMode (default `'absolute'`) Whether thresholds are absolute or a percentage. `'absolute'` or `'percentage'`.
+   * @param graphStyle (default `'line'`) The type of graph to draw. `'line'`, `'bars'`, or `'points'`.
    * @param legendMode (default `list`) How to display (or not) the legend. `'list`', `'table'`, or `'hidden`'.
    * @param legendPlacement (default `bottom`) Where to display the legend. `'bottom`' or `'right'`.
    * @param legendValues (default `[]`) A list of values to calculate and display in the legend. Options are: `'lastNotNull'`, `'last'`, `'firstNotNull'`, `'first'`, `'min'`, `'max'`, `'mean'`, `'sum'`, `'count'`, `'range'`, `'delta'`, `'step'`, `'diff'`, `'logmin'`, `'allIsZero'`, `'allIsNull'`, `'changeCount'`, `'distinctCount'`, `'diffperc'`, `'allValues'`, `'uniqueValues'`.
-   * @param graphStyle (default `'line'`) The type of graph to draw. `'line'`, `'bars'`, or `'points'`.
    * @param lineInterpolation (default `'linear'`) The interpolation method to use when `graphStyle` is `'line'`. `'linear'`, '`smooth'`, `'stepBefore'`, or `'stepAfter'`.
    * @param lineStyle (default `solid`) The draw style of the line when `graphStyle` is `'line'`. `'solid'`, `'dash'`, or `'dot'`.
    * @param lineDashSegments When `graphStyle` is `'line'`, an array specifying the length of dashes and gaps when `lineStyle` is `'dash'` or the gaps between dots when `lineStyle` is `'dot'`.
    * @param lineWidth (default `1`) The thickness of the line to draw when `graphStyle` is `'line'` or `'bars'`.
+   * @param barAlignment (default `'center'`) How bars should be aligned when `graphStyle` is `'bars'`. `'left'`, `'center'`, or `'right'`.
    * @param connectNullValues (default `false`) When graphStyle` is `'line'`, whether to connect null values or not. Can also specify a number of seconds beyond which points will not be connected. `true`, `false`, `<number of seconds>`.
    * @param fillOpacity (default `0`) The opacity to fill the area beneath the graph when `graphStyle` is `'line'` or `'bars'`.
-   * @param stackSeries (default `'none'`) How series should be stacked. `'none'`, `'normal'`, or `'100%'`.
-   * @param barAlignment (default `'center'`) How bars should be aligned when `graphStyle` is `'bars'`. `'left'`, `'center'`, or `'right'`.
-   * @param gradientMode (default `none`) The gradient style to apply to the fill when `graphStyle` is `'line'` or `'bars'`. `'none'`, `'opacity'`, `'hue'`, or `'scheme'`.
    * @param showPoints (default `'auto'`) When `graphStyle` is `'line'` or '`bars``, whether to display datapoints on the graph. `'auto'`, `'always'`, or `'never'`.
    * @param pointSize (default `5`) The size of points on the graph.
+   * @param stackSeries (default `'none'`) How series should be stacked. `'none'`, `'normal'`, or `'100%'`.
+   * @param gradientMode (default `none`) The gradient style to apply to the fill when `graphStyle` is `'line'` or `'bars'`. `'none'`, `'opacity'`, `'hue'`, or `'scheme'`.
    * @param axisPlacement (default `'auto'`) How the axis should be aligned. `'auto'`, `'left'`, `'right'`, or `'hidden'`.
    * @param axisLabel (default `''`) The axis label.
    * @param axisWidth (default `'auto'`) The axis width.
    * @param axisSoftMin (optional) The soft minimum for the axis.
    * @param axisSoftMax (optional) The soft maximum for the axis.
-   * @param axisShowGridLines (default `'auto'`) Whether to show grid lines. `'auto'`, `true`, or `false`
+   * @param axisShowGridLines (default `'auto'`) Whether to show grid lines. `'auto'`, `true`, or `false`.
    * @param axisLogBase (optional) If set, scale the axis logarithmically with the given base (valid values `2` or `10`). If not set, the axis will have a linear scale.
-   * @param repeat (optional) Name of variable that should be used to repeat this panel.
-   * @param repeatDirection (default `'h'`) 'h' for horizontal or 'v' for vertical.
-   * @param repeatMaxPerRow (optional) How many panels to limit each row to when repeating horizontally,
    * @param tooltip (default `'single'`) The tooltip mode, `'single'`, `'all'`, or `'hidden'`.
    * @param tooltipSort (default `'none'`) Value sort order when tooltip mode is `'all'`. `'none'`, `'ascending'`, or `'descending'`.
-   * @param transparent (optional) Whether to display the panel without a background.
-   * @param unit (optional) The unit to use for values.
-   * @param min (optional) The minimum value to display.
-   * @param max (optional) The maximum value to display.
-   * @param decimals (optional) The number of decimal points to display.
-   * @param seriesName (optional) Override the series or field name.
-   * @param colorMode (default `'palette-classic'`) The color mode to use.
-   * @param colorBy (default `'last'`) How to determine the color to use. `'last'`, `'min'`, or `'max'`.
-   * @param fixedColor (optional) The color to use when `colorMode` is `'fixed'`.
-   * @param noValue (optional) What to show when there is no value.
-   * @param thresholdDisplay (default `'off'`) How thresholds should be visualised. `'off'`, `'line'`, `'area'`, or `'line+area'`
-   * @param thresholdMode (default `'absolute'`) Whether thresholds are absolute or a percentage. `'absolute'` or `'percentage'`
+   * @param links (optional) Array of links for the panel.
+   * @param repeat (optional) Name of variable that should be used to repeat this panel.
+   * @param repeatDirection (default `'h'`) 'h' for horizontal or 'v' for vertical.
+   * @param repeatMaxPerRow (optional) How many panels to limit each row to when repeating horizontally.
+   * @return A json that represents a graph panel.
    *
    * @method addTarget(target) Adds a target object.
    * @method addTargets(targets) Adds an array of targets.
+   * @method addLink(link) Add a link to the panel.
+   * @method addLinks(links) Adds an array of links to the panel.
+   * @method addThreshold(color, value=null) Adds a threshold.
    * @method addValueMapping(value, color, displayText=null) Adds a value mapping.
    * @method addRangeMapping(from, to, color, displayText=null) Adds a range mapping.
    * @method addRegexMapping(pattern, color, displayText=null) Adds a regular expression mapping.
    * @method addSpecialMapping(match, color, displayText=null) Adds a special mapping.
    * @method addDataLink(url, title='', newWindow=false) Adds a data link.
-   * @method addThreshold(color, value=null) Adds a threshold.
    * @method addOverridesForField(field, overrides) Add a list of overrides for a named field.
    * @method addOverridesForFieldsMatchingRegex(regex, overrides) Add a list of overrides for field names matching a given regex.
    * @method addOverridesForFieldsOfType(type, overrides) Add a list of overrides for fields of a given type.
@@ -63,6 +67,18 @@
   new(
     title,
     description=null,
+    transparent=false,
+    unit=null,
+    min=null,
+    max=null,
+    decimals=null,
+    displayName=null,
+    colorMode='palette-classic',
+    fixedColor=null,
+    colorBy='last',
+    noValue=null,
+    thresholdDisplay='off',
+    thresholdMode='absolute',
     graphStyle='line',
     legendMode='list',
     legendPlacement='bottom',
@@ -85,193 +101,181 @@
     axisSoftMax=null,
     axisShowGridLines='auto',
     axisLogBase=null,
+    tooltip='single',
+    tooltipSort=null,
+    links=[],
     repeat=null,
     repeatDirection='h',
     repeatMaxPerRow=null,
-    tooltip='single',
-    tooltipSort=null,
-    transparent=null,
-    unit=null,
-    min=null,
-    max=null,
-    decimals=null,
-    seriesName=null,
-    colorMode='palette-classic',
-    fixedColor=null,
-    colorBy='last',
-    noValue=null,
-    thresholdDisplay='off',
-    thresholdMode='absolute',
-  )::
-    {
-      [if description != null then 'description']: description,
-      fieldConfig: {
-        defaults: {
-          color: {
-            mode: colorMode,
-            [if colorMode == 'fixed' && fixedColor != null then 'fixedColor']: fixedColor,
-            [if colorBy != 'last' then 'seriesBy']: colorBy,
+  ):: {
+    type: 'timeseries',
+    title: title,
+    [if description != null then 'description']: description,
+    [if transparent then 'transparent']: transparent,
+    fieldConfig: {
+      defaults: {
+        custom: {
+          axisLabel: axisLabel,
+          axisPlacement: axisPlacement,
+          [if axisWidth != 'auto' then 'axisWidth']: axisWidth,
+          [if axisSoftMin != null then 'axisSoftMin']: axisSoftMin,
+          [if axisSoftMax != null then 'axisSoftMax']: axisSoftMax,
+          [if axisShowGridLines != 'auto' then 'axisGridShow']: axisShowGridLines,
+          barAlignment: {
+            left: -1,
+            center: 0,
+            right: 1,
+          }[barAlignment],
+          drawStyle: graphStyle,
+          fillOpacity: fillOpacity,
+          gradientMode: gradientMode,
+          hideFrom: {
+            legend: false,
+            tooltip: false,
+            viz: false,
           },
-          custom: {
-            axisLabel: axisLabel,
-            axisPlacement: axisPlacement,
-            [if axisWidth != 'auto' then 'axisWidth']: axisWidth,
-            [if axisSoftMin != null then 'axisSoftMin']: axisSoftMin,
-            [if axisSoftMax != null then 'axisSoftMax']: axisSoftMax,
-            [if axisShowGridLines != 'auto' then 'axisGridShow']: axisShowGridLines,
-            barAlignment: {
-              left: -1,
-              center: 0,
-              right: 1,
-            }[barAlignment],
-            drawStyle: graphStyle,
-            fillOpacity: fillOpacity,
-            gradientMode: gradientMode,
-            hideFrom: {
-              legend: false,
-              tooltip: false,
-              viz: false,
-            },
-            lineInterpolation: lineInterpolation,
-            [if graphStyle == 'line' then 'lineStyle']: {
-              fill: lineStyle,
-              [if lineStyle == 'dash' then 'dash']: if lineDashSegments != null then lineDashSegments else [10, 10],
-              [if lineStyle == 'dot' then 'dash']: if lineDashSegments != null then lineDashSegments else [0, 10],
-            },
-            lineWidth: lineWidth,
-            pointSize: pointSize,
-            scaleDistribution: {
-              type: if axisLogBase == null then 'linear' else 'log',
-              [if axisLogBase != null then 'log']: axisLogBase,
-            },
-            showPoints: showPoints,
-            spanNulls: connectNullValues,
-            stacking: {
-              group: 'A',
-              mode: if stackSeries == '100%' then 'percent' else stackSeries,
-            },
-            thresholdsStyle: {
-              mode: thresholdDisplay,
-            },
+          lineInterpolation: lineInterpolation,
+          [if graphStyle == 'line' then 'lineStyle']: {
+            fill: lineStyle,
+            [if lineStyle == 'dash' then 'dash']: if lineDashSegments != null then lineDashSegments else [10, 10],
+            [if lineStyle == 'dot' then 'dash']: if lineDashSegments != null then lineDashSegments else [0, 10],
           },
-          mappings: [],
-          thresholds: {
-            mode: thresholdMode,
-            steps: [],
+          lineWidth: lineWidth,
+          pointSize: pointSize,
+          scaleDistribution: {
+            type: if axisLogBase == null then 'linear' else 'log',
+            [if axisLogBase != null then 'log']: axisLogBase,
           },
-          [if unit != null then 'unit']: unit,
-          [if min != null then 'min']: min,
-          [if max != null then 'max']: max,
-          [if decimals != null then 'decimals']: decimals,
-          [if seriesName != null then 'displayName']: seriesName,
-          [if noValue != null then 'noValue']: noValue,
-        },
-        overrides: [],
-      },
-      links: [],
-      options: {
-        legend: {
-          calcs: legendValues,
-          displayMode: legendMode,
-          placement: legendPlacement,
-        },
-        tooltip: {
-          mode: { single: 'single', all: 'multi', hidden: 'none' }[tooltip],
-          sort: if tooltip == 'all' && tooltipSort != null
-          then { ascending: 'asc', descending: 'desc' }[tooltipSort]
-          else 'none',
-        },
-      },
-      [if repeat != null then 'repeat']: repeat,
-      [if repeat != null then 'repeatDirection']: repeatDirection,
-      [if repeat != null && repeatDirection == 'h' && repeatMaxPerRow != null then 'maxPerRow']: repeatMaxPerRow,
-      targets: [],
-      title: title,
-      [if transparent != null then 'transparent']: transparent,
-      type: 'timeseries',
-      _nextTarget:: 0,
-      addLink(link):: self {
-        links+: [link],
-      },
-      addLinks(links):: std.foldl(function(p, t) p.addLink(t), links, self),
-      addTarget(target):: self {
-        // automatically ref id in added targets.
-        // https://github.com/kausalco/public/blob/master/klumps/grafana.libsonnet
-        local nextTarget = super._nextTarget,
-        _nextTarget: nextTarget + 1,
-        targets+: [target { refId: std.char(std.codepoint('A') + nextTarget) }],
-      },
-      addTargets(targets):: std.foldl(function(p, t) p.addTarget(t), targets, self),
-      _nextMapping:: 0,
-      local addMapping = function(type, options) self {
-        local nextMapping = super._nextMapping,
-        _nextMapping: nextMapping + 1,
-        fieldConfig+: { defaults+: { mappings+: [{ type: type, options: options(nextMapping) }] } },
-      },
-      addValueMapping(value, color, displayText=null)::
-        addMapping(type='value', options=function(index) {
-          [value]: {
-            color: color,
-            index: index,
-            [if displayText != null then 'text']: displayText,
+          showPoints: showPoints,
+          spanNulls: connectNullValues,
+          stacking: {
+            group: 'A',
+            mode: if stackSeries == '100%' then 'percent' else stackSeries,
           },
-        }),
-      addRangeMapping(from, to, color, displayText=null)::
-        addMapping(type='range', options=function(index) {
-          from: from,
-          to: to,
-          result: {
-            color: color,
-            index: index,
-            [if displayText != null then 'text']: displayText,
-          },
-        }),
-      addRegexMapping(pattern, color, displayText=null)::
-        addMapping(type='regex', options=function(index) {
-          pattern: pattern,
-          result: {
-            color: color,
-            index: index,
-            [if displayText != null then 'text']: displayText,
-          },
-        }),
-      addSpecialMapping(match, color, displayText=null)::
-        addMapping(type='special', options=function(index) {
-          match: match,
-          result: {
-            color: color,
-            index: index,
-            [if displayText != null then 'text']: displayText,
-          },
-        }),
-      addDataLink(url, title='', newWindow=false):: self {
-        fieldConfig+: {
-          defaults+: {
-            links+: [
-              {
-                title: title,
-                url: url,
-                [if newWindow == true then 'targetBlank']: true,
-              },
-            ],
+          thresholdsStyle: {
+            mode: thresholdDisplay,
           },
         },
+        mappings: [],
+        thresholds: {
+          mode: thresholdMode,
+          steps: [],
+        },
+        color: {
+          mode: colorMode,
+          [if colorMode == 'fixed' && fixedColor != null then 'fixedColor']: fixedColor,
+          [if colorBy != 'last' then 'seriesBy']: colorBy,
+        },
+        [if unit != null then 'unit']: unit,
+        [if min != null then 'min']: min,
+        [if max != null then 'max']: max,
+        [if decimals != null then 'decimals']: decimals,
+        [if displayName != null then 'displayName']: displayName,
+        [if noValue != null then 'noValue']: noValue,
       },
-      addThreshold(color, value=null):: self {
-        fieldConfig+: { defaults+: { thresholds+: { steps+: [{ color: color, value: value }] } } },
-      },
-      local addOverrides = function(matcher, overrides) self {
-        fieldConfig+: { overrides+: [{ matcher: matcher, properties: overrides }] },
-      },
-      addOverridesForField(field, overrides)::
-        addOverrides(matcher={ id: 'byName', options: field }, overrides=overrides),
-      addOverridesForFieldsMatchingRegex(regex, overrides)::
-        addOverrides(matcher={ id: 'byRegexp', options: regex }, overrides=overrides),
-      addOverridesForFieldsOfType(type, overrides)::
-        addOverrides(matcher={ id: 'byType', options: type }, overrides=overrides),
-      addOverridesForQuery(queryId, overrides)::
-        addOverrides(matcher={ id: 'byFrameRefID', options: queryId }, overrides=overrides),
+      overrides: [],
     },
+    links: links,
+    options: {
+      legend: {
+        calcs: legendValues,
+        displayMode: legendMode,
+        placement: legendPlacement,
+      },
+      tooltip: {
+        mode: { single: 'single', all: 'multi', hidden: 'none' }[tooltip],
+        sort: if tooltip == 'all' && tooltipSort != null
+        then { ascending: 'asc', descending: 'desc' }[tooltipSort]
+        else 'none',
+      },
+    },
+    [if repeat != null then 'repeat']: repeat,
+    [if repeat != null then 'repeatDirection']: repeatDirection,
+    [if repeat != null && repeatDirection == 'h' && repeatMaxPerRow != null then 'maxPerRow']: repeatMaxPerRow,
+    targets: [],
+    _nextTarget:: 0,
+    addThreshold(color, value=null):: self {
+      fieldConfig+: { defaults+: { thresholds+: { steps+: [{ color: color, value: value }] } } },
+    },
+    addLink(link):: self {
+      links+: [link],
+    },
+    addLinks(links):: std.foldl(function(p, t) p.addLink(t), links, self),
+    addTarget(target):: self {
+      // automatically ref id in added targets.
+      // https://github.com/kausalco/public/blob/master/klumps/grafana.libsonnet
+      local nextTarget = super._nextTarget,
+      _nextTarget: nextTarget + 1,
+      targets+: [target { refId: std.char(std.codepoint('A') + nextTarget) }],
+    },
+    addTargets(targets):: std.foldl(function(p, t) p.addTarget(t), targets, self),
+    _nextMapping:: 0,
+    local addMapping = function(type, options) self {
+      local nextMapping = super._nextMapping,
+      _nextMapping: nextMapping + 1,
+      fieldConfig+: { defaults+: { mappings+: [{ type: type, options: options(nextMapping) }] } },
+    },
+    addValueMapping(value, color, displayText=null)::
+      addMapping(type='value', options=function(index) {
+        [value]: {
+          color: color,
+          index: index,
+          [if displayText != null then 'text']: displayText,
+        },
+      }),
+    addRangeMapping(from, to, color, displayText=null)::
+      addMapping(type='range', options=function(index) {
+        from: from,
+        to: to,
+        result: {
+          color: color,
+          index: index,
+          [if displayText != null then 'text']: displayText,
+        },
+      }),
+    addRegexMapping(pattern, color, displayText=null)::
+      addMapping(type='regex', options=function(index) {
+        pattern: pattern,
+        result: {
+          color: color,
+          index: index,
+          [if displayText != null then 'text']: displayText,
+        },
+      }),
+    addSpecialMapping(match, color, displayText=null)::
+      addMapping(type='special', options=function(index) {
+        match: match,
+        result: {
+          color: color,
+          index: index,
+          [if displayText != null then 'text']: displayText,
+        },
+      }),
+    addDataLink(url, title='', newWindow=false):: self {
+      fieldConfig+: {
+        defaults+: {
+          links+: [
+            {
+              title: title,
+              url: url,
+              [if newWindow == true then 'targetBlank']: true,
+            },
+          ],
+        },
+      },
+    },
+    local addOverrides = function(matcher, overrides) self {
+      fieldConfig+: { overrides+: [{ matcher: matcher, properties: overrides }] },
+    },
+    addOverridesForField(field, overrides)::
+      addOverrides(matcher={ id: 'byName', options: field }, overrides=overrides),
+    addOverridesForFieldsMatchingRegex(regex, overrides)::
+      addOverrides(matcher={ id: 'byRegexp', options: regex }, overrides=overrides),
+    addOverridesForFieldsOfType(type, overrides)::
+      addOverrides(matcher={ id: 'byType', options: type }, overrides=overrides),
+    addOverridesForQuery(queryId, overrides)::
+      addOverrides(matcher={ id: 'byFrameRefID', options: queryId }, overrides=overrides),
+  },
   /**
    * Helpers for use with the addOverrides* methods of the timeseries panel.
    *

--- a/tests/table_panel/test_compiled.json
+++ b/tests/table_panel/test_compiled.json
@@ -38,6 +38,7 @@
          "showHeader": true
       },
       "pluginVersion": "9.2.1",
+      "targets": [ ],
       "title": "test",
       "transparent": true,
       "type": "table"
@@ -74,6 +75,7 @@
          "showHeader": true
       },
       "pluginVersion": "9.2.1",
+      "targets": [ ],
       "title": "test",
       "type": "table"
    },
@@ -130,6 +132,7 @@
          "showHeader": true
       },
       "pluginVersion": "9.2.1",
+      "targets": [ ],
       "title": "test",
       "type": "table"
    },
@@ -258,6 +261,7 @@
             "showHeader": true
          },
          "pluginVersion": "9.2.1",
+         "targets": [ ],
          "title": "with transformations",
          "transformations": [
             {
@@ -311,6 +315,7 @@
             "showHeader": true
          },
          "pluginVersion": "9.2.1",
+         "targets": [ ],
          "title": "with batch transformations",
          "transformations": [
             {

--- a/tests/timeseries_panel/test.jsonnet
+++ b/tests/timeseries_panel/test.jsonnet
@@ -34,7 +34,7 @@ local timeseries = grafana.timeseriesPanel;
       tooltip='all',
       tooltipSort='ascending',
       decimals=2,
-      seriesName='a name',
+      displayName='a name',
       colorBy='min',
       noValue='none',
     ),

--- a/tests/timeseries_panel/timeseries.jsonnet
+++ b/tests/timeseries_panel/timeseries.jsonnet
@@ -72,7 +72,7 @@ local overrides = grafana.timeseriesPanel.overrides;
   can_set_min: std.assertEqual(1234, grafana.timeseriesPanel.new(title='', min=1234).fieldConfig.defaults.min),
   can_set_max: std.assertEqual(5678, grafana.timeseriesPanel.new(title='', max=5678).fieldConfig.defaults.max),
   can_set_decimals: std.assertEqual(3, grafana.timeseriesPanel.new(title='', decimals=3).fieldConfig.defaults.decimals),
-  can_override_series_name: std.assertEqual('series name', grafana.timeseriesPanel.new(title='', seriesName='series name').fieldConfig.defaults.displayName),
+  can_override_display_name: std.assertEqual('display name', grafana.timeseriesPanel.new(title='', displayName='display name').fieldConfig.defaults.displayName),
   can_set_fixed_color: std.assertEqual({ mode: 'fixed', fixedColor: 'blue' }, grafana.timeseriesPanel.new(title='', colorMode='fixed', fixedColor='blue').fieldConfig.defaults.color),
   can_color_by_min: std.assertEqual('min', grafana.timeseriesPanel.new(title='', colorBy='min').fieldConfig.defaults.color.seriesBy),
   can_map_missing_values: std.assertEqual(123, grafana.timeseriesPanel.new(title='', noValue=123).fieldConfig.defaults.noValue),

--- a/tests/timeseries_panel/timeseries_compiled.json
+++ b/tests/timeseries_panel/timeseries_compiled.json
@@ -13,7 +13,7 @@
    "can_display_thresholds": true,
    "can_make_transparent": true,
    "can_map_missing_values": true,
-   "can_override_series_name": true,
+   "can_override_display_name": true,
    "can_set_decimals": true,
    "can_set_description": true,
    "can_set_fixed_color": true,


### PR DESCRIPTION
- Reorder the parameters to the timeseries panel to be consistent with the table panel.
- Rename `seriesName` to `displayName` in timeseries panel.
- Convert table panel identifiers to camelCase
- Rearrange the order of parameters for the table and timeseries panels to be consistent with other resources.
- Add an `addLinks` method to the table panel to be consistent with the timeseries panel.